### PR TITLE
Add a workflow to automatically generate tags

### DIFF
--- a/.github/workflows/auto-tag-new-version.yml
+++ b/.github/workflows/auto-tag-new-version.yml
@@ -1,0 +1,57 @@
+name: "Automatically tag new version"
+
+on:
+  workflow_call:
+    secrets:
+      github-token:
+        required: true
+
+jobs:
+  auto-tag-new-version:
+    name: "Automatically tag new version"
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: "Checkout"
+        uses: "actions/checkout@v4"
+        with:
+          fetch-depth: 0 # see https://github.com/actions/checkout/issues/1471
+          fetch-tags: true
+          persist-credentials: false
+      - name: "Extract version"
+        run: |
+          sudo apt-get update
+          sudo apt-get install --assume-yes --no-install-recommends --quiet pcregrep
+          VERSION=$(pcregrep -o1 "define\s*\(\s*['\"]PLUGIN_[A-Z]+_VERSION['\"]\s*,\s*['\"]([^'\"]+)['\"]\s*\)" setup.php)
+          echo "VERSION=${VERSION}" >> $GITHUB_ENV
+      - name: "Check if tag exists"
+        run: |
+          CREATE_TAG=no
+          if [[ ! -z "${{ env.VERSION }}" && -z "$(git tag -l ${{ env.VERSION }})" ]]; then
+            CREATE_TAG=yes
+          fi
+          echo "CREATE_TAG=${CREATE_TAG}" >> $GITHUB_ENV
+      - name: "Create release"
+        if: ${{ env.CREATE_TAG == 'yes' }}
+        uses: "actions/github-script@v7"
+        with:
+          # A PAT is required.
+          # From https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow:
+          # > When you use the repository's GITHUB_TOKEN to perform tasks, events triggered by the GITHUB_TOKEN,
+          # > with the exception of workflow_dispatch and repository_dispatch, will not create a new workflow run.
+          # > This prevents you from accidentally creating recursive workflow runs. For example, if a workflow run pushes
+          # > code using the repository's GITHUB_TOKEN, a new workflow will not run even when the repository
+          # > contains a workflow configured to run when push events occur.
+          github-token: ${{ secrets.github-token }}
+          script: |
+            try {
+              github.rest.git.createRef(
+                {
+                  ref: 'refs/tags/${{ env.VERSION }}',
+                  sha: context.sha,
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                }
+              );
+            } catch (error) {
+              core.setFailed(error.message);
+            }

--- a/README.md
+++ b/README.md
@@ -33,3 +33,29 @@ jobs:
       # otherwise, the description will be empty.
       release-body: ""
 ```
+
+## Automatically tag new version workflow
+
+This workflow can be used to automatically create a new tag when the plugin version in its `setup` file is updated.
+
+```yaml
+name: "Automatically tag new version"
+
+on:
+  push:
+    branches:
+      - "main"
+    paths:
+      - "setup.php"
+
+jobs:
+  auto-tag-new-version:
+    name: "Automatically tag new version"
+    uses: "glpi-project/plugin-release-workflows/.github/workflows/auto-tag-new-version.yml@v1"
+    secrets:
+      # The access token used when the new tag is pushed.
+      # This personal access token (PAT) is required to ensure that subsequent workflows that listen
+      # to the tag push event will be triggered.
+      # This PAT requires the `Content: read/write` permissions.
+      github-token: "${{ secrets.AUTOTAG_TOKEN }}"
+```


### PR DESCRIPTION
This workflow may help to simplify the release process.

In combination with the `Publish release` workflow, it could result in the following process:
 - the developper opens a PR with the `setup.php` and `plugin.xml` files update;
 - the developper merges this PR once CI tests are OK (he can also use the "auto merge" feature);
 - the merge operation triggers the `Automatically tag new version` workflow via `push setup.php file on main branch` event;
 - the new version is detected, and the tag is created and pushed;
 - the tag push triggers the `Publish release` workflow that build the release archive and publish the archive.

Tested by the commit https://github.com/cedric-anne/glpi-plugin-credit/commit/45e49f46b2e0eff787cf43c53fd97467f4c26a86 that triggers https://github.com/cedric-anne/glpi-plugin-credit/actions/runs/7903717281/job/21572273898 then https://github.com/cedric-anne/glpi-plugin-credit/actions/runs/7903721471/job/21572288219.