### PR TITLE
Fix(release): prevent syntax error using regex without bash

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -36,6 +36,7 @@ jobs:
           echo "PACKAGE_BASENAME=$(find "$(pwd)/dist/" -type f -name '*.tar.bz2' | xargs -n 1 basename)" >> $GITHUB_ENV
           echo "PACKAGE_PATH=$(find "$(pwd)/dist/" -type f -name '*.tar.bz2')" >> $GITHUB_ENV
       - name: "Compute values"
+        shell: bash
         run: |
           TAG_NAME="${{ inputs.tag }}"
           RELEASE_NAME="${{ inputs.release-name }}"


### PR DESCRIPTION
See : 

https://github.com/glpi-project/glpi-inventory-plugin/actions/runs/14752158067/job/41411945955
https://github.com/pluginsGLPI/news/actions/runs/14754201118/job/41418396931

```shell
syntax error: unexpected "(" (expecting "then")
``` 