### PR TITLE
Switch to GLPI core tools

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -25,7 +25,7 @@ jobs:
       options: --user 1001 # using built-in image user, otherwise GitHub Actions can't write file to the container
     steps:
       - name: "Checkout setup.php"
-        uses: "actions/checkout@v6"
+        uses: "actions/checkout@v7"
         with:
           ref: "${{ inputs.tag }}"
           sparse-checkout: setup.php
@@ -39,7 +39,7 @@ jobs:
           fi
           echo "PLUGIN_KEY=$PLUGIN_KEY" >> $GITHUB_ENV
       - name: "Checkout Plugin"
-        uses: "actions/checkout@v6"
+        uses: "actions/checkout@v7"
         with:
           ref: "${{ inputs.tag }}"
           fetch-tags: true

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -21,7 +21,7 @@ jobs:
     name: "Publish release"
     runs-on: "ubuntu-latest"
     container:
-      image: "ghcr.io/froozeify/githubactions-glpi-apache:latest" #TODO: Change this for glpi-project once core tools is migrated in official 11.0/bf
+      image: "ghcr.io/glpi-project/githubactions-glpi-apache:latest"
       options: --user 1001 # using built-in image user, otherwise GitHub Actions can't write file to the container
     steps:
       - name: "Checkout setup.php"

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -132,8 +132,9 @@ jobs:
             }
       - name: "Verify XML download URL"
         if: ${{ !cancelled() }}
+        working-directory: plugins/${{ env.PLUGIN_KEY }}/
         run: |
-          PLUGIN_KEY=$(echo "${{ github.repository }}" | cut -d'/' -f2)
+          PLUGIN_KEY="${{ env.PLUGIN_KEY }}"
           XML_FILE=""
           for candidate in "plugin.xml" "${PLUGIN_KEY}.xml"; do
             if [[ -f "$candidate" ]]; then

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -49,8 +49,9 @@ jobs:
         run: |
           sudo ln -s $GITHUB_WORKSPACE/plugins/$PLUGIN_KEY /var/www/glpi/plugins/$PLUGIN_KEY
           # Fix permissions for logs and other writable dirs
+          # Open the whole tree for writing so any tool (present or future) can write wherever it needs to.
           sudo mkdir -p /var/www/glpi/tests/files/_log
-          sudo chmod -R 777 /var/www/glpi/
+          sudo chmod -R a+rwX /var/www/glpi/
           # Ensure git trusts the directory
           git config --global --add safe.directory '*'
       - name: "Build release archive"

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -56,7 +56,7 @@ jobs:
       - name: "Build release archive"
         working-directory: /var/www/glpi/
         run: |
-          php bin/console tools:plugin:release --plugin=${{ env.PLUGIN_KEY }} --no-interaction --force --verbose
+          php bin/console tools:plugin:release --plugin=${{ env.PLUGIN_KEY }} --dest="plugins/${{ env.PLUGIN_KEY }}/dist/${{ env.PLUGIN_KEY }}-${{ inputs.tag }}.tar.bz2" --no-interaction --force --verbose
           echo "PACKAGE_BASENAME=$(find "plugins/${{ env.PLUGIN_KEY }}/dist/" -type f -name '*.tar.bz2' | xargs --max-args=1 basename)" >> $GITHUB_ENV
           echo "PACKAGE_PATH=$(find "/var/www/glpi/plugins/${{ env.PLUGIN_KEY }}/dist/" -type f -name '*.tar.bz2')" >> $GITHUB_ENV
       - name: "Compute values"

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -58,8 +58,9 @@ jobs:
         working-directory: /var/www/glpi/
         run: |
           php bin/console tools:plugin:release --plugin=${{ env.PLUGIN_KEY }} --dest="plugins/${{ env.PLUGIN_KEY }}/dist/${{ env.PLUGIN_KEY }}-${{ inputs.tag }}.tar.bz2" --no-interaction --force --verbose
-          echo "PACKAGE_BASENAME=$(find "plugins/${{ env.PLUGIN_KEY }}/dist/" -type f -name '*.tar.bz2' | xargs --max-args=1 basename)" >> $GITHUB_ENV
-          echo "PACKAGE_PATH=$(find "/var/www/glpi/plugins/${{ env.PLUGIN_KEY }}/dist/" -type f -name '*.tar.bz2')" >> $GITHUB_ENV
+          PACKAGE_PATH=$(find "/var/www/glpi/plugins/${{ env.PLUGIN_KEY }}/dist/" -type f -name '*.tar.bz2')
+          echo "PACKAGE_PATH=$PACKAGE_PATH" >> $GITHUB_ENV
+          echo "PACKAGE_BASENAME=$(basename "$PACKAGE_PATH")" >> $GITHUB_ENV
       - name: "Compute values"
         working-directory: /var/www/glpi/plugins/${{ env.PLUGIN_KEY }}/
         run: |

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -21,21 +21,39 @@ jobs:
     name: "Publish release"
     runs-on: "ubuntu-latest"
     container:
-      image: "ghcr.io/glpi-project/plugin-builder"
+      image: "ghcr.io/glpi-project/githubactions-glpi-apache:latest"
     steps:
-      - name: "Checkout"
-        uses: "actions/checkout@v7"
+      - name: "Checkout setup.php"
+        uses: "actions/checkout@v6"
+        with:
+          ref: "${{ inputs.tag }}"
+          sparse-checkout: setup.php
+          path: tmp_setup
+      - name: "Get Plugin Key"
+        run: |
+          PLUGIN_KEY=$(sed --quiet 's/.*function plugin_version_\([a-z0-9_]\+\).*/\1/p' tmp_setup/setup.php | head --lines=1)
+          if [ -z "$PLUGIN_KEY" ]; then
+            echo "Could not extract plugin key from setup.php"
+            exit 1
+          fi
+          echo "PLUGIN_KEY=$PLUGIN_KEY" >> $GITHUB_ENV
+      - name: "Checkout Plugin"
+        uses: "actions/checkout@v6"
         with:
           ref: "${{ inputs.tag }}"
           fetch-tags: true
-      - name: "Build release archive"
+          path: plugins/${{ env.PLUGIN_KEY }}
+      - name: "Link Plugin to GLPI"
         run: |
-          composer install --no-progress --no-suggest --no-interaction --prefer-dist
-          git config --global --add safe.directory $(pwd)
-          vendor/bin/plugin-release --assume-yes --dont-check --nogithub --nosign --release "${{ inputs.tag }}" --verbose
-          echo "PACKAGE_BASENAME=$(find "$(pwd)/dist/" -type f -name '*.tar.bz2' | xargs -n 1 basename)" >> $GITHUB_ENV
-          echo "PACKAGE_PATH=$(find "$(pwd)/dist/" -type f -name '*.tar.bz2')" >> $GITHUB_ENV
+          sudo ln -s $GITHUB_WORKSPACE/plugins/$PLUGIN_KEY /var/www/glpi/plugins/$PLUGIN_KEY
+      - name: "Build release archive"
+        working-directory: /var/www/glpi/
+        run: |
+          php bin/console tools:plugin:release --plugin=${{ env.PLUGIN_KEY }} --no-interaction --force --verbose
+          echo "PACKAGE_BASENAME=$(find "plugins/${{ env.PLUGIN_KEY }}/dist/" -type f -name '*.tar.bz2' | xargs --max-args=1 basename)" >> $GITHUB_ENV
+          echo "PACKAGE_PATH=$(find "/var/www/glpi/plugins/${{ env.PLUGIN_KEY }}/dist/" -type f -name '*.tar.bz2')" >> $GITHUB_ENV
       - name: "Compute values"
+        working-directory: /var/www/glpi/plugins/${{ env.PLUGIN_KEY }}/
         run: |
           TAG_NAME="${{ inputs.tag }}"
           RELEASE_NAME="${{ inputs.release-name }}"
@@ -53,7 +71,7 @@ jobs:
               RELEASE_BODY="${COMPAT}"
             fi
           fi
-          if [[ $( echo ${TAG_NAME} | grep -E "\-(alpha|beta|rc)[0-9]*$" ) ]]; then
+          if [[ $( echo ${TAG_NAME} | grep --extended-regexp "\-(alpha|beta|rc)[0-9]*$" ) ]]; then
             PRERELEASE="true"
           else
             PRERELEASE="false"

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -21,7 +21,8 @@ jobs:
     name: "Publish release"
     runs-on: "ubuntu-latest"
     container:
-      image: "ghcr.io/glpi-project/githubactions-glpi-apache:latest"
+      image: "ghcr.io/froozeify/githubactions-glpi-apache:latest" #TODO: Change this for glpi-project once core tools is migrated in official 11.0/bf
+      options: --user 1001 # using built-in image user, otherwise GitHub Actions can't write file to the container
     steps:
       - name: "Checkout setup.php"
         uses: "actions/checkout@v6"
@@ -42,10 +43,16 @@ jobs:
         with:
           ref: "${{ inputs.tag }}"
           fetch-tags: true
+          fetch-depth: 0
           path: plugins/${{ env.PLUGIN_KEY }}
       - name: "Link Plugin to GLPI"
         run: |
           sudo ln -s $GITHUB_WORKSPACE/plugins/$PLUGIN_KEY /var/www/glpi/plugins/$PLUGIN_KEY
+          # Fix permissions for logs and other writable dirs
+          sudo mkdir -p /var/www/glpi/tests/files/_log
+          sudo chmod -R 777 /var/www/glpi/
+          # Ensure git trusts the directory
+          git config --global --add safe.directory '*'
       - name: "Build release archive"
         working-directory: /var/www/glpi/
         run: |


### PR DESCRIPTION
- This PR is aimed to use the native core tools that will be release soon (https://github.com/glpi-project/glpi/pull/22465)
  For now I have created an image based on the branch so we can test.
  This should tested once https://github.com/glpi-project/glpi/pull/22465 is officially merged

I have tested with [mreporting plugin](https://github.com/froozeify/GLPI_plugin_mreporting) (fork)

https://github.com/froozeify/GLPI_plugin_mreporting/releases

10.x CI : https://github.com/froozeify/GLPI_plugin_mreporting/actions/runs/21394446711
11.x CI : https://github.com/froozeify/GLPI_plugin_mreporting/actions/runs/21394458696

---
CI After rebase
10.x CI : https://github.com/froozeify/GLPI_plugin_mreporting/actions/runs/30817862670
11.x CI : https://github.com/froozeify/GLPI_plugin_mreporting/actions/runs/30817569397

--- 
Close #15