### PR TITLE
Feat: verify XML download URL after release is published

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -92,7 +92,14 @@ jobs:
       - name: "Verify XML download URL"
         if: ${{ !cancelled() }}
         run: |
-          XML_FILE=$(find . -maxdepth 1 -name "*.xml" | head -1)
+          PLUGIN_KEY=$(echo "${{ github.repository }}" | cut -d'/' -f2)
+          XML_FILE=""
+          for candidate in "plugin.xml" "${PLUGIN_KEY}.xml"; do
+            if [[ -f "$candidate" ]]; then
+              XML_FILE="$candidate"
+              break
+            fi
+          done
           if [[ -z "$XML_FILE" ]]; then
             echo "No plugin XML file found, skipping check."
             exit 0

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -89,3 +89,25 @@ jobs:
             } catch (error) {
               core.setFailed(error.message);
             }
+      - name: "Verify XML download URL"
+        if: ${{ !cancelled() }}
+        run: |
+          XML_FILE=$(find . -maxdepth 1 -name "*.xml" | head -1)
+          if [[ -z "$XML_FILE" ]]; then
+            echo "No plugin XML file found, skipping check."
+            exit 0
+          fi
+          EXPECTED_URL="https://github.com/${{ github.repository }}/releases/download/${{ env.TAG_NAME }}/${{ env.PACKAGE_BASENAME }}"
+          XML_URL=$(grep -oP '(?<=<download_url>)[^<]+' "$XML_FILE" | grep "/${{ env.TAG_NAME }}/" | head -1)
+          if [[ -z "$XML_URL" ]]; then
+            echo "❌ No <download_url> entry found in $XML_FILE for tag ${{ env.TAG_NAME }}"
+            echo "   Working URL: $EXPECTED_URL"
+            exit 1
+          fi
+          if [[ "$XML_URL" != "$EXPECTED_URL" ]]; then
+            echo "❌ URL mismatch in $XML_FILE:"
+            echo "   Found:       $XML_URL"
+            echo "   Working URL: $EXPECTED_URL"
+            exit 1
+          fi
+          echo "✅ XML download URL matches the published asset: $XML_URL"

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -100,9 +100,8 @@ jobs:
           EXPECTED_URL="https://github.com/${{ github.repository }}/releases/download/${{ env.TAG_NAME }}/${{ env.PACKAGE_BASENAME }}"
           XML_URL=$(grep -oP '(?<=<download_url>)[^<]+' "$XML_FILE" | grep "/${{ env.TAG_NAME }}/" | head -1)
           if [[ -z "$XML_URL" ]]; then
-            echo "❌ No <download_url> entry found in $XML_FILE for tag ${{ env.TAG_NAME }}"
-            echo "   Working URL: $EXPECTED_URL"
-            exit 1
+            echo "No <download_url> entry for tag ${{ env.TAG_NAME }} in $XML_FILE, skipping check."
+            exit 0
           fi
           if [[ "$XML_URL" != "$EXPECTED_URL" ]]; then
             echo "❌ URL mismatch in $XML_FILE:"


### PR DESCRIPTION
After a GitHub release is published, the workflow now checks whether the plugin XML file contains a `<download_url>` for the current tag. If the entry is present but points to the wrong URL, the step fails and prints both the found URL and the correct working URL to copy into the XML.

If no entry exists for the tag, the check is silently skipped.